### PR TITLE
fix(gulp-i18n-wxml): 修复重复写 wxs 标签到 wxml 中

### DIFF
--- a/packages/gulp-i18n-wxml/index.ts
+++ b/packages/gulp-i18n-wxml/index.ts
@@ -42,6 +42,10 @@ const gulpI18nWxmlTransformer = (options?: Options) => through.obj((file: File, 
       relativeWxsPath = relativeWxsPath.replace(/\\/g, '/')
     }
     const wxsTag = getWxsTag(relativeWxsPath, wxsModuleName)
+    if (transformedContents.indexOf(wxsTag) !== -1) {
+      // has already write wxs tag into wxml.
+      return cb(null, file)
+    }
     file.contents = Buffer.concat([Buffer.from(wxsTag), Buffer.from(transformedContents)])
   } catch (err) {
     console.log('error:', err)


### PR DESCRIPTION
场景：将编译后的内容会写到源 wxml 中，重复编译会重复添加标签。
![image](https://user-images.githubusercontent.com/12679581/135406161-d7ea9544-8a50-4ed9-a9eb-302b947ebb8b.png)
